### PR TITLE
Replacing REQUEST with GET

### DIFF
--- a/pagination/middleware.py
+++ b/pagination/middleware.py
@@ -4,7 +4,7 @@ def get_page(self):
     integer representing the current page.
     """
     try:
-        return int(self.REQUEST['page'])
+        return int(self.GET['page'])
     except (KeyError, ValueError, TypeError):
         return 1
 


### PR DESCRIPTION
WSGIRequest.REQUEST was removed in django 1.9:
https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9
